### PR TITLE
Fix the CMake for GCC 4.6

### DIFF
--- a/examples/colliding_balls/CMakeLists.txt
+++ b/examples/colliding_balls/CMakeLists.txt
@@ -2,13 +2,15 @@ cmake_minimum_required(VERSION 2.6)
 
 project(LIBES_DEMO CXX)
 
-add_definitions(-Wall -g -O2 -std=c++11)
+if (NOT MSVC)
+  add_definitions(-Wall -g -O2)
+  add_definitions(-std=c++0x) # equivalent of -std=c++11, but the later works only for GCC >= 4.7
+endif (NOT MSVC)
 
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(LIBES0 REQUIRED libes0)
 pkg_check_modules(SFML2 REQUIRED sfml-graphics)
-
 
 find_path(BOX2D_INCLUDE_DIRS Box2D/Box2D.h)
 find_library(BOX2D_LIBRARIES Box2D)

--- a/examples/simple_balls/CMakeLists.txt
+++ b/examples/simple_balls/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 2.6)
 
 project(LIBES_DEMO CXX)
 
-add_definitions(-Wall -g -O2 -std=c++11)
+if (NOT MSVC)
+  add_definitions(-Wall -g -O2)
+  add_definitions(-std=c++0x) # equivalent of -std=c++11, but the later works only for GCC >= 4.7
+endif (NOT MSVC)
 
 find_package(PkgConfig REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,8 @@ project(LIBES CXX)
 
 include(CPackConfig.cmake)
 
-add_definitions(-Wall -g -O2)
-
 if (NOT MSVC)
+  add_definitions(-Wall -g -O2)
   add_definitions(-std=c++0x) # equivalent of -std=c++11, but the later works only for GCC >= 4.7
 endif (NOT MSVC)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,9 @@ include(CPackConfig.cmake)
 
 add_definitions(-Wall -g -O2)
 
-if (WIN32)
-  add_definitions(-std=c++0x)
-else (WIN32)
-  add_definitions(-std=c++11)
-endif (WIN32)
+if (NOT MSVC)
+  add_definitions(-std=c++0x) # equivalent of -std=c++11, but the later works only for GCC >= 4.7
+endif (NOT MSVC)
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 


### PR DESCRIPTION
- GCC 4.4, 4.5 and 4.6 uses the flag "-std=c++0x" instead of "-std=c++11"
- GCC 4.7 and above can use any two of them

NOTE: this is only part of a fix for building against GCC 4.6 ; I will also provide a fix for the source code
NOTE: GCC 4.6 is used under Ubuntu 12.04 current LTS, and so it is the default for Travis Continuous Integration free services

Cheers,
SRombauts
